### PR TITLE
[#3]

### DIFF
--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="userId" value="-55cee217:1938610a07e:-7ffa" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -3,7 +3,9 @@
   <component name="MaterialThemeProjectNewConfig">
     <option name="metadata">
       <MTProjectMetadataState>
-        <option name="userId" value="-55cee217:1938610a07e:-7ffa" />
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="33f4538a:19356ed1ed6:-7ffe" />
       </MTProjectMetadataState>
     </option>
   </component>

--- a/dorm-front/src/app/onboarding/page.tsx
+++ b/dorm-front/src/app/onboarding/page.tsx
@@ -1,15 +1,27 @@
 "use client";
-import ServiceAccessRights from "@/components/onboarding/ServiceAccessRights";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
 import NicknameSetting from "@/components/onboarding/NicknameSetting";
 import SchoolInfoSetting from "@/components/onboarding/SchoolInfoSetting";
 import PhotoStudentIDCard from "@/components/onboarding/PhotoStudentIDCard";
 import WaitForCompletion from "@/components/onboarding/WaitForCompletion";
-import { useState } from "react";
+import { getKaKaoAccessToken } from "@/lib/api/onboarding";
 import { StepOnboarding } from "@/types/onboarding/type";
 import { useRouter } from "next/navigation";
 
 const OnBoarding = () => {
+  const params = useSearchParams();
   const [step, setStep] = useState<StepOnboarding>("NicknameSetting");
+
+  useEffect(() => {
+    if (params.get("code")) {
+      getKaKaoAccessToken(params.get("code")).then((r) => {
+        console.log("r", r);
+      });
+    }
+  }, []);
+
   return (
     <main>
       {step === "NicknameSetting" && <NicknameSetting onNext={setStep} />}

--- a/dorm-front/src/app/onboarding/page.tsx
+++ b/dorm-front/src/app/onboarding/page.tsx
@@ -6,7 +6,7 @@ import NicknameSetting from "@/components/onboarding/NicknameSetting";
 import SchoolInfoSetting from "@/components/onboarding/SchoolInfoSetting";
 import PhotoStudentIDCard from "@/components/onboarding/PhotoStudentIDCard";
 import WaitForCompletion from "@/components/onboarding/WaitForCompletion";
-import { getKaKaoAccessToken } from "@/lib/api/onboarding";
+import { getJWTToken, getKaKaoAccessToken } from "@/lib/api/onboarding";
 import { StepOnboarding } from "@/types/onboarding/type";
 import { useRouter } from "next/navigation";
 
@@ -15,9 +15,15 @@ const OnBoarding = () => {
   const [step, setStep] = useState<StepOnboarding>("NicknameSetting");
 
   useEffect(() => {
-    if (params.get("code")) {
+    if (params.get("code") && localStorage.getItem("kakaoAccessToken") === null) {
       getKaKaoAccessToken(params.get("code")).then((r) => {
-        console.log("r", r);
+        localStorage.setItem("kakaoAccessToken", r?.access_token);
+        getJWTToken(r?.access_token).then((res) => {
+          if (res) {
+            localStorage.setItem("accessToken", res.headers.accesstoken);
+            localStorage.setItem("refreshToken", res.headers.refreshtoken);
+          }
+        });
       });
     }
   }, []);

--- a/dorm-front/src/app/page.tsx
+++ b/dorm-front/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function page() {
         <div className={"h-[36px]"}></div>
       </div>
       <Link
-        href={"http://43.202.254.127:8080/oauth2/authorization/kakao"}
+        href={`https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_REST_API_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_REDIRECT_URI}&response_type=code`}
         className={
           "absolute bottom-5 flex gap-x-2 items-center justify-center w-[90%] bg-[#F9E000] rounded-full font-semibold py-[14px]"
         }>

--- a/dorm-front/src/lib/api/onboarding.ts
+++ b/dorm-front/src/lib/api/onboarding.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { client } from "@/lib/axios";
+import { client, sendRequest } from "@/lib/axios";
 import { ProfileSettingType } from "@/types/global";
 
 export const getKaKaoAccessToken = async (code: string | null) => {
@@ -25,6 +25,20 @@ export const getKaKaoAccessToken = async (code: string | null) => {
   } catch (error) {
     // 에러 처리
     console.error("카카오 엑세스토큰 가져오는데 에러 발생:", error);
+  }
+};
+
+export const getJWTToken = async (accessToken: string) => {
+  try {
+    const response = await sendRequest({
+      method: "POST",
+      data: { accessToken: accessToken },
+      url: "/api/login",
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error("JWT 에러 발생:", error);
   }
 };
 

--- a/dorm-front/src/lib/api/onboarding.ts
+++ b/dorm-front/src/lib/api/onboarding.ts
@@ -1,12 +1,39 @@
+import axios from "axios";
+
 import { client } from "@/lib/axios";
 import { ProfileSettingType } from "@/types/global";
+
+export const getKaKaoAccessToken = async (code: string | null) => {
+  try {
+    const response = await axios.post(
+      "https://kauth.kakao.com/oauth/token",
+      {
+        grant_type: "authorization_code",
+        client_id: process.env.NEXT_PUBLIC_REST_API_KEY,
+        redirect_uri: process.env.NEXT_PUBLIC_REDIRECT_URI,
+        code: code,
+        client_secret: process.env.NEXT_PUBLIC_CLIENT_SECRET,
+      },
+      {
+        headers: {
+          "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+        },
+      },
+    );
+    // 성공적인 응답 처리
+    return response.data;
+  } catch (error) {
+    // 에러 처리
+    console.error("카카오 엑세스토큰 가져오는데 에러 발생:", error);
+  }
+};
 
 export const getSearchDuplicateNickName = async (searchValue: string) => {
   try {
     const response = await client.get(`/members/check?nickname=${searchValue}`, {
       headers: {
         "Content-type": "application/json",
-        "AccessToken": process.env.NEXT_PUBLIC_ACCESS_TOKEN,
+        AccessToken: process.env.NEXT_PUBLIC_ACCESS_TOKEN,
       },
     });
     // 성공적인 응답 처리
@@ -22,7 +49,7 @@ export const putProfileData = async (data: ProfileSettingType) => {
     const response = await client.put(`/api/members/initial-profiles`, data, {
       headers: {
         "Content-type": "application/json",
-        "AccessToken": process.env.NEXT_PUBLIC_ACCESS_TOKEN,
+        AccessToken: process.env.NEXT_PUBLIC_ACCESS_TOKEN,
       },
     });
     // 성공적인 응답 처리

--- a/dorm-front/src/lib/axios.ts
+++ b/dorm-front/src/lib/axios.ts
@@ -60,7 +60,6 @@ const getTokensFromLocalStorage = () => {
 const sendRequest = async (config: any) => {
   try {
     console.log("In send Request" + localStorage.getItem("accessToken"));
-    console.log("최종", client.defaults.baseURL + config.url);
     return await client(config);
   } catch (error) {
     const axiosError = error as AxiosError; // AxiosError로 캐스팅

--- a/dorm-front/src/lib/axios.ts
+++ b/dorm-front/src/lib/axios.ts
@@ -71,11 +71,11 @@ const sendRequest = async (config: any) => {
       if (refreshToken) {
         try {
           const response = await client.post(
-            config.url,
+            "/api/reissue",
             {}, // 여기에 요청 바디 데이터를 넣어줘야 함
             {
               headers: {
-                RefreshToken: refreshToken,
+                RefreshToken: "Bearer " + refreshToken,
               },
             },
           );

--- a/dorm-front/src/lib/axios.ts
+++ b/dorm-front/src/lib/axios.ts
@@ -4,9 +4,23 @@ const client = axios.create({
   baseURL: "http://13.124.186.20:8080",
   headers: {
     "Content-type": "application/json",
-    AccessToken:
-      "Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlcyI6WyJST0xFX0dVRVNUIl0sImVtYWlsIjoidGtkZ2g2NDI3QG5hdmVyLmNvbSIsInN1YiI6InRrZGdoNjQyN0BuYXZlci5jb20iLCJpYXQiOjE3MDk0NjEwNDUsImV4cCI6MTcwOTcyMDI0NX0.u_S6efRZoZUBcCxLcGG2Szio20CUMn2qsVLgNl5TCB8",
+    AccessToken: localStorage.getItem("accessToken"),
   },
+  transformResponse: [
+    (data, headers) => {
+      let parsedData;
+      try {
+        parsedData = JSON.parse(data); // JSON 문자열을 객체로 변환
+      } catch (e) {
+        parsedData = data; // JSON 파싱에 실패하면 원본 데이터를 유지
+      }
+
+      return {
+        data: parsedData,
+        headers: headers,
+      };
+    },
+  ],
   withCredentials: true,
 });
 

--- a/dorm-front/src/lib/axios.ts
+++ b/dorm-front/src/lib/axios.ts
@@ -1,13 +1,123 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 
 const client = axios.create({
-  baseURL: "http://43.202.254.127:8080/api",
+  baseURL: "http://13.124.186.20:8080",
   headers: {
     "Content-type": "application/json",
-    "AccessToken":  process.env.NEXT_PUBLIC_ACCESS_TOKEN,
+    AccessToken:
+      "Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlcyI6WyJST0xFX0dVRVNUIl0sImVtYWlsIjoidGtkZ2g2NDI3QG5hdmVyLmNvbSIsInN1YiI6InRrZGdoNjQyN0BuYXZlci5jb20iLCJpYXQiOjE3MDk0NjEwNDUsImV4cCI6MTcwOTcyMDI0NX0.u_S6efRZoZUBcCxLcGG2Szio20CUMn2qsVLgNl5TCB8",
   },
+  withCredentials: true,
 });
 
-export const swrGetFetcher = (url: string) => client.get(url).then((res) => res.data);
+/**
+ * 토큰 관리를 위한 함수
+ */
+const setAuthHeader = (token: string) => {
+  if (token) {
+    client.defaults.headers["AccessToken"] = `${token}`;
+    localStorage.removeItem("accessToken");
+  } else {
+    delete client.defaults.headers["AccessToken"];
+  }
+};
 
-export { client };
+/**
+ * 액세스 토큰 및 리프레시 토큰을 저장하는 함수
+ */
+const saveTokensToLocalStorage = (accessToken: string, refreshToken: string) => {
+  localStorage.setItem("accessToken", accessToken);
+  localStorage.setItem("refreshToken", refreshToken);
+};
+
+/**
+ * 액세스 토큰 및 리프레시 토큰을 불러오는 함수
+ */
+const getTokensFromLocalStorage = () => {
+  const accessToken = localStorage.getItem("accessToken");
+  const refreshToken = localStorage.getItem("refreshToken");
+  return { accessToken, refreshToken };
+};
+
+/**
+ * API 요청을 보내는 함수
+ * @param config 는 axios 요청
+ */
+const sendRequest = async (config: any) => {
+  try {
+    console.log("In send Request" + localStorage.getItem("accessToken"));
+    console.log("최종", client.defaults.baseURL + config.url);
+    return await client(config);
+  } catch (error) {
+    const axiosError = error as AxiosError; // AxiosError로 캐스팅
+    console.log("axiosError", axiosError);
+    if (axiosError.response && axiosError.response.status === 401) {
+      // 만료된 액세스 ㅇ토큰일 경우 리프레시 토큰으로 갱신
+      const { refreshToken } = getTokensFromLocalStorage();
+      if (refreshToken) {
+        try {
+          const response = await client.post(
+            config.url,
+            {}, // 여기에 요청 바디 데이터를 넣어줘야 함
+            {
+              headers: {
+                RefreshToken: refreshToken,
+              },
+            },
+          );
+
+          // headers는 객체로 직접 접근
+          const newAccessToken = response.headers["AccessToken"];
+          const newRefreshToken = response.headers["RefreshToken"];
+
+          if (newAccessToken && newRefreshToken) {
+            // 갱신된 토큰을 처리
+            localStorage.removeItem("refreshToken");
+            localStorage.removeItem("accessToken");
+            setAuthHeader(newAccessToken);
+            saveTokensToLocalStorage(newAccessToken, newRefreshToken);
+
+            // 이전 요청 재시도
+            return await client({
+              headers: {
+                AccessToken: newAccessToken,
+              },
+              method: config.method,
+              data: config.data,
+              url: config.url,
+            });
+          } else {
+            console.error("새로운 토큰이 없습니다.");
+          }
+        } catch (refreshError) {
+          // 리프레시 토큰으로의 갱신에 실패하면 로그인 페이지로 리다이렉트 또는 다른 처리 수행
+          console.error("토큰 갱신에 실패했습니다..", refreshError);
+          // 예: 로그인 페이지로 리다이렉트
+        }
+      }
+    }
+
+    // 401 에러가 아니거나 리프레시 토큰이 없는 경우 또는 갱신에 실패한 경우
+    throw error;
+  }
+};
+
+export const swrGetFetcher = async (url: any) => {
+  try {
+    // 액세스 토큰을 헤더에 담아 요청 보내기
+
+    const response = await sendRequest({
+      headers: {
+        AccessToken: localStorage.getItem("accessToken"),
+      },
+      method: "GET",
+      url: url,
+    });
+    return response.data;
+  } catch (error) {
+    // 에러 처리
+    console.error("에러 발생:", error);
+  }
+};
+
+export { client, getTokensFromLocalStorage, saveTokensToLocalStorage, sendRequest, setAuthHeader };

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dorm",
+  "name": "web-front",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dorm",
+  "name": "web-front",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

1. 카카오에서 리다이렉트로 인가코드를 요청받아 이 인가코드를 가지고 카카오 api에 post요청하여 accessToken을 발급받습니다.
2. 카카오 accessToken을 가지고 `/api/login`에 요청하여 우리 앱의 accessToken과 refreshToken을 발급 받습니다.
3. accessToken 발급이 만료되었을 때, refreshToken로 '/api/reissue' 재발급 요청을 보냅니다.

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

response의 header에 직접 접근할 수 없어 accessToken과 refreshToken을 발급받을 수 없다는 문제가 발생하였습니다.
axios.creat 속성에 
```
transformResponse: [
    (data, headers) => {
      let parsedData;
      try {
        parsedData = JSON.parse(data); // JSON 문자열을 객체로 변환
      } catch (e) {
        parsedData = data; // JSON 파싱에 실패하면 원본 데이터를 유지
      }

      return {
        data: parsedData,
        headers: headers,
      };
    },
  ],

```
해당 코드를 추가하여 header값이 console에 보여 접근 가능하도록 구현하였습니다. 