### PR TITLE
[#12] 온보딩 페이지 기능 구현

### DIFF
--- a/dorm-front/src/app/(main)/admin/page.tsx
+++ b/dorm-front/src/app/(main)/admin/page.tsx
@@ -56,7 +56,7 @@ const AdminPage = () => {
                         onClick={() => {
                           putMemberApproval(nonVerifiedStudentCard.memberId).then(() => {
                             mutate();
-                          });;
+                          });
                         }}
                         className={"border border-gray1 text-gray5 py-[6px] rounded-full px-5"}>
                         승인

--- a/dorm-front/src/app/(main)/admin/page.tsx
+++ b/dorm-front/src/app/(main)/admin/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Image from "next/image";
 import { useCallback, useEffect, useState } from "react";
 import { useInView } from "react-intersection-observer";
 
@@ -9,6 +10,7 @@ import { VerifyMembersResponseType } from "@/types/onboarding/type";
 
 const AdminPage = () => {
   const [isOpenStudentCardUrl, setIsOpenStudentCardUrl] = useState(false);
+  const [studentCardIdUrl, setStudentCardIdUrl] = useState("");
   const [ref, inView] = useInView();
   const { nonVerifiedStudentCardList, setSize, mutate } = useVerifyMembers();
 
@@ -28,7 +30,9 @@ const AdminPage = () => {
 
   return (
     <div>
-      {isOpenStudentCardUrl ? <></> : null}
+      {isOpenStudentCardUrl ? (
+        <Image alt={studentCardIdUrl} src={studentCardIdUrl} width={300} height={300}></Image>
+      ) : null}
       <Header headerType={"dynamic"} title={"학생증 승인"} />
       <section className={"flex flex-col gap-y-3 mt-10 px-5 py-3"}>
         {nonVerifiedStudentCardList && nonVerifiedStudentCardList.length !== 0
@@ -39,9 +43,14 @@ const AdminPage = () => {
                     <div
                       className={"flex "}
                       onClick={() => {
+                        setStudentCardIdUrl(nonVerifiedStudentCard.studentCardUrl);
                         setIsOpenStudentCardUrl(true);
                       }}>
-                      <div className={"flex flex-col text-h5"}>
+                      <div
+                        onClick={() => {
+                          setIsOpenStudentCardUrl(true);
+                        }}
+                        className={"flex flex-col text-h5"}>
                         <div className={"flex"}>
                           <span>{nonVerifiedStudentCard.name}</span>
                           <span>/</span>

--- a/dorm-front/src/app/(main)/admin/page.tsx
+++ b/dorm-front/src/app/(main)/admin/page.tsx
@@ -5,11 +5,12 @@ import { useInView } from "react-intersection-observer";
 import Header from "@/components/common/Header";
 import { putMemberApproval, putMemberRejection } from "@/lib/api/onboarding";
 import useVerifyMembers from "@/lib/hooks/useVerifyMembers";
+import { VerifyMembersResponseType } from "@/types/onboarding/type";
 
 const AdminPage = () => {
   const [isOpenStudentCardUrl, setIsOpenStudentCardUrl] = useState(false);
   const [ref, inView] = useInView();
-  const { nonVerifiedStudentCardList, setSize } = useVerifyMembers();
+  const { nonVerifiedStudentCardList, setSize, mutate } = useVerifyMembers();
 
   // 전체
   const getMoreItem = useCallback(async () => {
@@ -31,9 +32,8 @@ const AdminPage = () => {
       <Header headerType={"dynamic"} title={"학생증 승인"} />
       <section className={"flex flex-col gap-y-3 mt-10 px-5 py-3"}>
         {nonVerifiedStudentCardList && nonVerifiedStudentCardList.length !== 0
-          ? nonVerifiedStudentCardList.map((nonVerifiedStudentCardResponse) => {
-              // console.log('nonVerifiedStudentCardList', nonVerifiedStudentCardList)
-              return nonVerifiedStudentCardResponse?.data.nonVerifiedStudentCards.map((nonVerifiedStudentCard) => {
+          ? nonVerifiedStudentCardList.map((nonVerifiedStudentCardResponse: VerifyMembersResponseType) => {
+              return nonVerifiedStudentCardResponse?.data.data.nonVerifiedStudentCards.map((nonVerifiedStudentCard) => {
                 return (
                   <div ref={ref} key={nonVerifiedStudentCard.memberId} className={"border-b border-gray1 py-4"}>
                     <div
@@ -51,17 +51,21 @@ const AdminPage = () => {
                       </div>
                     </div>
 
-                    <div className={"flex gap-x-3"}>
+                    <div className={"flex gap-x-3 justify-end"}>
                       <button
                         onClick={() => {
-                          putMemberApproval(nonVerifiedStudentCard.memberId);
+                          putMemberApproval(nonVerifiedStudentCard.memberId).then(() => {
+                            mutate();
+                          });;
                         }}
                         className={"border border-gray1 text-gray5 py-[6px] rounded-full px-5"}>
                         승인
                       </button>
                       <button
                         onClick={() => {
-                          putMemberRejection(nonVerifiedStudentCard.memberId);
+                          putMemberRejection(nonVerifiedStudentCard.memberId).then(() => {
+                            mutate();
+                          });
                         }}
                         className={"bg-primary text-white py-[6px] rounded-full px-5"}>
                         거부

--- a/dorm-front/src/app/(main)/admin/page.tsx
+++ b/dorm-front/src/app/(main)/admin/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { useCallback, useEffect, useState } from "react";
+import { useInView } from "react-intersection-observer";
+
+import Header from "@/components/common/Header";
+import { putMemberApproval, putMemberRejection } from "@/lib/api/onboarding";
+import useVerifyMembers from "@/lib/hooks/useVerifyMembers";
+
+const AdminPage = () => {
+  const [isOpenStudentCardUrl, setIsOpenStudentCardUrl] = useState(false);
+  const [ref, inView] = useInView();
+  const { nonVerifiedStudentCardList, setSize } = useVerifyMembers();
+
+  // 전체
+  const getMoreItem = useCallback(async () => {
+    if (nonVerifiedStudentCardList) {
+      await setSize((prev: number) => prev + 1);
+    }
+    return;
+  }, []);
+
+  useEffect(() => {
+    if (inView) {
+      getMoreItem();
+    }
+  }, [inView]);
+
+  useEffect(() => {
+    console.log("nonVerifiedStudentCardList", nonVerifiedStudentCardList);
+  }, [nonVerifiedStudentCardList]);
+
+  return (
+    <div>
+      {isOpenStudentCardUrl ? <></> : null}
+      <Header headerType={"dynamic"} title={"학생증 승인"} />
+      <section className={"mt-20 px-5 py-3"}>
+        {nonVerifiedStudentCardList && nonVerifiedStudentCardList.length !== 0
+          ? nonVerifiedStudentCardList.map((nonVerifiedStudentCardResponse) => {
+              // console.log('nonVerifiedStudentCardList', nonVerifiedStudentCardList)
+              return nonVerifiedStudentCardResponse?.data.nonVerifiedStudentCards.map((nonVerifiedStudentCard) => {
+                return (
+                  <div ref={ref} key={nonVerifiedStudentCard.memberId} className={"flex justify-between items-center"}>
+                    <div
+                      className={"flex "}
+                      onClick={() => {
+                        setIsOpenStudentCardUrl(true);
+                      }}>
+                      <div className={"flex flex-col text-h5"}>
+                        <div className={"flex"}>
+                          <span>{nonVerifiedStudentCard.name}</span>
+                          <span>/</span>
+                          <span>{nonVerifiedStudentCard.Department}</span>
+                        </div>
+                        <span>{nonVerifiedStudentCard.studentNumber}</span>
+                      </div>
+                    </div>
+
+                    <div className={"flex gap-x-3"}>
+                      <button
+                        onClick={() => {
+                          putMemberApproval(nonVerifiedStudentCard.memberId);
+                        }}
+                        className={"border border-gray1 text-gray5 py-[6px] rounded-full px-5"}>
+                        승인
+                      </button>
+                      <button
+                        onClick={() => {
+                          putMemberRejection(nonVerifiedStudentCard.memberId);
+                        }}
+                        className={"bg-primary text-white py-[6px] rounded-full px-5"}>
+                        거부
+                      </button>
+                    </div>
+                  </div>
+                );
+              });
+            })
+          : null}
+      </section>
+    </div>
+  );
+};
+export default AdminPage;

--- a/dorm-front/src/app/(main)/admin/page.tsx
+++ b/dorm-front/src/app/(main)/admin/page.tsx
@@ -29,13 +29,13 @@ const AdminPage = () => {
     <div>
       {isOpenStudentCardUrl ? <></> : null}
       <Header headerType={"dynamic"} title={"학생증 승인"} />
-      <section className={"mt-20 px-5 py-3"}>
+      <section className={"flex flex-col gap-y-3 mt-10 px-5 py-3"}>
         {nonVerifiedStudentCardList && nonVerifiedStudentCardList.length !== 0
           ? nonVerifiedStudentCardList.map((nonVerifiedStudentCardResponse) => {
               // console.log('nonVerifiedStudentCardList', nonVerifiedStudentCardList)
               return nonVerifiedStudentCardResponse?.data.nonVerifiedStudentCards.map((nonVerifiedStudentCard) => {
                 return (
-                  <div ref={ref} key={nonVerifiedStudentCard.memberId} className={"flex justify-between items-center"}>
+                  <div ref={ref} key={nonVerifiedStudentCard.memberId} className={"border-b border-gray1 py-4"}>
                     <div
                       className={"flex "}
                       onClick={() => {

--- a/dorm-front/src/app/(main)/admin/page.tsx
+++ b/dorm-front/src/app/(main)/admin/page.tsx
@@ -25,10 +25,6 @@ const AdminPage = () => {
     }
   }, [inView]);
 
-  useEffect(() => {
-    console.log("nonVerifiedStudentCardList", nonVerifiedStudentCardList);
-  }, [nonVerifiedStudentCardList]);
-
   return (
     <div>
       {isOpenStudentCardUrl ? <></> : null}

--- a/dorm-front/src/app/onboarding/page.tsx
+++ b/dorm-front/src/app/onboarding/page.tsx
@@ -3,16 +3,16 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import NicknameSetting from "@/components/onboarding/NicknameSetting";
-import SchoolInfoSetting from "@/components/onboarding/SchoolInfoSetting";
 import PhotoStudentIDCard from "@/components/onboarding/PhotoStudentIDCard";
+import SchoolInfoSetting from "@/components/onboarding/SchoolInfoSetting";
+import ServiceAccessRights from "@/components/onboarding/ServiceAccessRights";
 import WaitForCompletion from "@/components/onboarding/WaitForCompletion";
 import { getJWTToken, getKaKaoAccessToken } from "@/lib/api/onboarding";
 import { StepOnboarding } from "@/types/onboarding/type";
-import { useRouter } from "next/navigation";
 
 const OnBoarding = () => {
   const params = useSearchParams();
-  const [step, setStep] = useState<StepOnboarding>("NicknameSetting");
+  const [step, setStep] = useState<StepOnboarding>("ServiceAccessRights");
 
   useEffect(() => {
     if (params.get("code") && localStorage.getItem("kakaoAccessToken") === null) {
@@ -30,6 +30,7 @@ const OnBoarding = () => {
 
   return (
     <main>
+      {step === "ServiceAccessRights" && <ServiceAccessRights onNext={setStep} />}
       {step === "NicknameSetting" && <NicknameSetting onNext={setStep} />}
       {step === "SchoolInfoSetting" && <SchoolInfoSetting onNext={setStep} onBefore={setStep} />}
       {step === "PhotoStudentIDCard" && <PhotoStudentIDCard onNext={setStep} onBefore={setStep} />}

--- a/dorm-front/src/components/onboarding/NicknameSetting.tsx
+++ b/dorm-front/src/components/onboarding/NicknameSetting.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/navigation";
 import qs from "query-string";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, SVGProps, useEffect, useState } from "react";
 import * as React from "react";
 
 import Header from "@/components/common/Header";
@@ -140,3 +140,9 @@ const NicknameSetting = (props: Props) => {
   );
 };
 export default NicknameSetting;
+
+const CheckIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={18} height={13} fill="none" {...props}>
+    <path stroke="#FF7E8D" strokeLinecap="round" strokeWidth={2} d="m1 5.149 5.025 5.378a2 2 0 0 0 2.923 0L17 1.909" />
+  </svg>
+);

--- a/dorm-front/src/components/onboarding/NicknameSetting.tsx
+++ b/dorm-front/src/components/onboarding/NicknameSetting.tsx
@@ -2,15 +2,18 @@ import { useRouter } from "next/navigation";
 import qs from "query-string";
 import { Dispatch, SetStateAction, SVGProps, useEffect, useState } from "react";
 import * as React from "react";
+import { useRecoilState } from "recoil";
 
 import Header from "@/components/common/Header";
 import useDebounce from "@/hooks/useDebounce";
 import { getSearchDuplicateNickName } from "@/lib/api/onboarding";
+import { profileSettingAtom } from "@/recoil/onboarding/atom";
 import {
   SearchDuplicateNickNameResponseType,
   SearchDuplicateNickNameType,
   StepOnboarding,
 } from "@/types/onboarding/type";
+import { ProfileSettingType } from "@/types/global";
 
 interface Props {
   onNext: Dispatch<SetStateAction<StepOnboarding>>;
@@ -24,6 +27,7 @@ const NicknameSetting = (props: Props) => {
   const debouncedValue = useDebounce<string>(searchValue, 100);
   const router = useRouter();
   const [duplicateStatus, setDuplicateStatus] = useState<boolean | null>(null);
+  const [profileInitialSetting, setProfileInitialSetting] = useRecoilState<ProfileSettingType>(profileSettingAtom);
 
   useEffect(() => {
     const query = {
@@ -124,6 +128,10 @@ const NicknameSetting = (props: Props) => {
         <button
           disabled={duplicateStatus === null ? true : duplicateStatus}
           onClick={() => {
+            setProfileInitialSetting((prevState: ProfileSettingType) => ({
+              ...prevState,
+              nickname: searchValue,
+            }));
             onNext("SchoolInfoSetting");
           }}
           className={

--- a/dorm-front/src/components/onboarding/NicknameSetting.tsx
+++ b/dorm-front/src/components/onboarding/NicknameSetting.tsx
@@ -8,12 +8,8 @@ import Header from "@/components/common/Header";
 import useDebounce from "@/hooks/useDebounce";
 import { getSearchDuplicateNickName } from "@/lib/api/onboarding";
 import { profileSettingAtom } from "@/recoil/onboarding/atom";
-import {
-  SearchDuplicateNickNameResponseType,
-  SearchDuplicateNickNameType,
-  StepOnboarding,
-} from "@/types/onboarding/type";
 import { ProfileSettingType } from "@/types/global";
+import { SearchDuplicateNickNameResponseType, StepOnboarding } from "@/types/onboarding/type";
 
 interface Props {
   onNext: Dispatch<SetStateAction<StepOnboarding>>;

--- a/dorm-front/src/components/onboarding/OnboardingCollegeFilter.tsx
+++ b/dorm-front/src/components/onboarding/OnboardingCollegeFilter.tsx
@@ -20,7 +20,7 @@ const OnboardingCollegeFilter = (props: Props) => {
 
   return (
     <>
-      <div className="absolute bg-white z-10 w-[90%] rounded-[20px] border-[1px] border-gray1 h-[335px] overflow-y-scroll">
+      <div className="absolute top-[85px] bg-white z-10 w-full rounded-[20px] border-[1px] border-gray1 h-[335px] overflow-y-scroll">
         {colleges.slice(1).map((college, index) => {
           return (
             <div

--- a/dorm-front/src/components/onboarding/OnboardingCollegeFilter.tsx
+++ b/dorm-front/src/components/onboarding/OnboardingCollegeFilter.tsx
@@ -2,17 +2,18 @@ import React from "react";
 import { SetterOrUpdater } from "recoil";
 
 import { ProfileSettingType } from "@/types/global";
+import { CollegeType } from "@/types/onboarding/type";
 
 interface Props {
-  colleges: string[];
+  colleges: CollegeType[];
   setPostData: SetterOrUpdater<ProfileSettingType>;
   setIsClickFilter: React.Dispatch<React.SetStateAction<boolean>>;
 }
 const OnboardingCollegeFilter = (props: Props) => {
   const { colleges, setIsClickFilter, setPostData } = props;
 
-  const updatePostData = (college: string) => {
-    setPostData((prevState) => ({
+  const updatePostData = (college: CollegeType) => {
+    setPostData((prevState: ProfileSettingType) => ({
       ...prevState,
       collegeType: college,
     }));

--- a/dorm-front/src/components/onboarding/OnboardingDepartmentFilter.tsx
+++ b/dorm-front/src/components/onboarding/OnboardingDepartmentFilter.tsx
@@ -20,20 +20,21 @@ const OnboardingDepartmentFilter = (props: Props) => {
 
   return (
     <>
-      <div className="absolute bg-white z-10 w-[90%] rounded-[20px] border-[1px] border-gray1 min-h-fit max-h-[335px] overflow-y-scroll">
-        {departments.map((department, index) => {
-          return (
-            <div
-              key={index}
-              className="py-3 px-4 hover:bg-gray0"
-              onClick={() => {
-                updatePostData(department);
-                setIsClickFilter(false);
-              }}>
-              {department}
-            </div>
-          );
-        })}
+      <div className="absolute top-[85px] bg-white z-10 w-full rounded-[20px] border-[1px] border-gray1 min-h-fit max-h-[335px] overflow-y-scroll">
+        {departments &&
+          departments.map((department, index) => {
+            return (
+              <div
+                key={index}
+                className="py-3 px-4 hover:bg-gray0"
+                onClick={() => {
+                  updatePostData(department);
+                  setIsClickFilter(false);
+                }}>
+                {department}
+              </div>
+            );
+          })}
       </div>
     </>
   );

--- a/dorm-front/src/components/onboarding/OnboardingDormitoryFilter.tsx
+++ b/dorm-front/src/components/onboarding/OnboardingDormitoryFilter.tsx
@@ -20,7 +20,7 @@ const OnboardingDormitoryFilter = (props: Props) => {
 
   return (
     <>
-      <div className="absolute bg-white z-10 w-[90%] rounded-[20px] border-[1px] border-gray1">
+      <div className="absolute top-[85px] bg-white z-10 w-full rounded-[20px] border-[1px] border-gray1">
         {dormList.map((dorm, index) => {
           return (
             <div

--- a/dorm-front/src/components/onboarding/PhotoStudentIDCard.tsx
+++ b/dorm-front/src/components/onboarding/PhotoStudentIDCard.tsx
@@ -1,8 +1,13 @@
 import Image from "next/image";
 import * as React from "react";
+import { Dispatch, FormEvent, SetStateAction, useEffect, useRef, useState } from "react";
+import { useRecoilState } from "recoil";
 
 import Header from "@/components/common/Header";
-import { Dispatch, SetStateAction } from "react";
+import { postArticleImage } from "@/lib/api/board";
+import { putProfileInitialData } from "@/lib/api/onboarding";
+import { profileSettingAtom } from "@/recoil/onboarding/atom";
+import { ProfileSettingType } from "@/types/global";
 import { StepOnboarding } from "@/types/onboarding/type";
 interface Props {
   onNext: Dispatch<SetStateAction<StepOnboarding>>;
@@ -10,13 +15,86 @@ interface Props {
 }
 const PhotoStudentIDCard = (props: Props) => {
   const { onNext, onBefore } = props;
+  const imgRef = useRef<HTMLInputElement>(null);
+  const [uploadImage, setUploadImage] = useState("");
+  const [profileInitialSetting, setProfileInitialSetting] = useRecoilState<ProfileSettingType>(profileSettingAtom);
+  const [isSubmitting, setIsSubmitting] = useState(false); // 제출 트리거
 
   const onBack = () => {
     onBefore("SchoolInfoSetting");
   };
 
+  // 이미지 미리보기 설정
+  const handleImagePreview = async () => {
+    const files = imgRef.current?.files;
+    let reader = new FileReader();
+    if (files) {
+      reader.readAsDataURL(files[0]);
+    }
+    reader.onloadend = () => {
+      setUploadImage(reader.result as string);
+    };
+  };
+
+  /**
+   * 이미지가 있을 때 form 제출 함수
+   */
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault(); // 폼 제출 시 새로고침 방지
+    const formData = new FormData();
+    if (imgRef.current?.files && imgRef.current.files[0]) {
+      formData.append("file", imgRef.current.files[0]);
+    }
+
+    try {
+      try {
+        await postArticleImage(formData).then((response) => {
+          console.log("S3성공", response);
+          if (response.data) {
+            setProfileInitialSetting((prevData) => ({
+              ...prevData,
+              profileUrl: response.data.imageUrl, // 업로드된 이미지 URL을 postData에 추가
+            }));
+          }
+        });
+        setIsSubmitting(true); // 제출 중 상태로 변경
+      } catch (error) {
+        console.error("이미지 업로드 중 오류 발생:", error);
+        throw error; // 오류 발생 시 throw하여 Promise.all이 멈추도록 함
+      }
+    } catch (error) {
+      console.error("폼 제출 중 오류 발생:", error);
+    }
+  };
+
+  /**
+   * 이미지가 있을 때 form 제출
+   * isSubmitting 트리거를 사용하여 제출
+   */
+  useEffect(() => {
+    if (isSubmitting) {
+      submitPost().then(() => {
+        onNext("WaitForCompletion");
+      });
+    }
+  }, [isSubmitting]);
+
+  /**
+   * put 요청
+   */
+  const submitPost = async () => {
+    try {
+      const response = await putProfileInitialData(profileInitialSetting); // API 호출
+      console.log(response);
+    } catch (error) {
+      console.error("폼 제출 중 오류 발생:", error);
+    } finally {
+      setIsSubmitting(false); // 제출 후 상태를 false로 변경
+    }
+  };
+
   return (
-    <>
+    <form onSubmit={uploadImage.length !== 0 ? handleSubmit : submitPost}>
       <Header headerType={"dynamic"} title={"프로필 설정"} onBack={onBack}></Header>
       <div className={"h-[60px]"}></div>
       <div className={"mx-5"}>
@@ -28,37 +106,62 @@ const PhotoStudentIDCard = (props: Props) => {
         </div>
 
         <div className={"mt-[32px] text-h2 font-semibold"}>학생증 인증을 해주세요.</div>
-
-        <div>
-          <div className={"mt-[24px]"}>충북대 학생을 인증하면</div>
-          <div className={"flex flex-col gap-y-3 mt-[12px]"}>
-            <div className={"flex justify-between items-center gap-x-3 bg-gray0 rounded-[20px] px-5 py-3"}>
-              <Image src={"/onboarding/종이비행기.png"} width={100} height={100} alt={"/onboarding/종이비행기.png"} />
-              <div className={"flex flex-col"}>
-                <div className={"font-semibold"}>기숙사에 대한 다양한 정보와</div>
-                <div className={"font-semibold"}>소식을 빠르게 전해요!</div>
-              </div>
-            </div>
-            <div className={"flex justify-between items-center gap-x-3 bg-gray0 rounded-[20px] px-5 py-3"}>
-              <Image src={"/onboarding/손뼉.png"} width={100} height={100} alt={"/onboarding/종이비행기.png"} />
-              <div className={"flex flex-col"}>
-                <div className={"font-semibold"}>룸메 매칭으로</div>
-                <div className={"font-semibold"}>원하는 룸메를 추천해요!</div>
-              </div>
+        {uploadImage.length !== 0 ? (
+          <div className={"mt-5 flex justify-center items-center"}>
+            <div className={"relative  w-[320px] h-[550px]"}>
+              <Image alt={uploadImage} src={uploadImage} fill className={"absolute object-cover"} />
             </div>
           </div>
-        </div>
+        ) : (
+          <section>
+            <div className={"mt-[24px]"}>충북대 학생을 인증하면</div>
+            <div className={"flex flex-col gap-y-3 mt-[12px]"}>
+              <div className={"flex justify-between items-center gap-x-3 bg-gray0 rounded-[20px] px-5 py-3"}>
+                <Image src={"/onboarding/종이비행기.png"} width={100} height={100} alt={"/onboarding/종이비행기.png"} />
+                <div className={"flex flex-col"}>
+                  <div className={"font-semibold"}>기숙사에 대한 다양한 정보와</div>
+                  <div className={"font-semibold"}>소식을 빠르게 전해요!</div>
+                </div>
+              </div>
+              <div className={"flex justify-between items-center gap-x-3 bg-gray0 rounded-[20px] px-5 py-3"}>
+                <Image src={"/onboarding/손뼉.png"} width={100} height={100} alt={"/onboarding/종이비행기.png"} />
+                <div className={"flex flex-col"}>
+                  <div className={"font-semibold"}>룸메 매칭으로</div>
+                  <div className={"font-semibold"}>원하는 룸메를 추천해요!</div>
+                </div>
+              </div>
+            </div>
+          </section>
+        )}
       </div>
-      <button
-        onClick={() => {
-          onNext("WaitForCompletion");
-        }}
-        className={"left-5 py-[15px] absolute bottom-5 text-white bg-primary rounded-full w-[90%] text-h5"}>
-        학생증 촬영하기
-      </button>
-    </>
+      <input
+        type={"file"}
+        accept={"image/*"}
+        id="image"
+        name="image"
+        onChange={handleImagePreview}
+        multiple
+        ref={imgRef}
+        style={{ display: "none" }}></input>
+      {uploadImage.length !== 0 ? (
+        <button
+          type={"submit"}
+          className={
+            "flex justify-center items-center left-5 py-[15px] absolute bottom-5 text-white bg-primary rounded-full w-[90%] text-h5"
+          }>
+          제출하기
+        </button>
+      ) : (
+        <label id={"image"} htmlFor="image">
+          <div
+            className={
+              "flex justify-center items-center left-5 py-[15px] absolute bottom-5 text-white bg-primary rounded-full w-[90%] text-h5"
+            }>
+            학생증 촬영하기
+          </div>
+        </label>
+      )}
+    </form>
   );
-}
+};
 export default PhotoStudentIDCard;
-
-

--- a/dorm-front/src/components/onboarding/SchoolInfoSetting.tsx
+++ b/dorm-front/src/components/onboarding/SchoolInfoSetting.tsx
@@ -198,12 +198,12 @@ const SchoolInfoSetting = (props: Props) => {
             </div>
             {isDormFilterClick ? (
               <OnboardingDormitoryFilter
-                dormList={ARTICLE_DORM_LIST}
+                dormList={MEMBER_DORM_LIST}
                 setPostData={setPostData}
                 setIsClickFilter={setIsDormFilterClick}
               />
             ) : null}
-          </div>
+          </section>
         </div>
       </div>
       <button

--- a/dorm-front/src/components/onboarding/SchoolInfoSetting.tsx
+++ b/dorm-front/src/components/onboarding/SchoolInfoSetting.tsx
@@ -7,10 +7,9 @@ import Header from "@/components/common/Header";
 import OnboardingCollegeFilter from "@/components/onboarding/OnboardingCollegeFilter";
 import OnboardingDepartmentFilter from "@/components/onboarding/OnboardingDepartmentFilter";
 import OnboardingDormitoryFilter from "@/components/onboarding/OnboardingDormitoryFilter";
-import { putProfileData } from "@/lib/api/onboarding";
 import { profileSettingAtom } from "@/recoil/onboarding/atom";
 import { StepOnboarding } from "@/types/onboarding/type";
-import { ARTICLE_DORM_LIST } from "@/utils/dorm";
+import { MEMBER_DORM_LIST } from "@/utils/dorm";
 import { COLLEGE_LIST } from "@/utils/onboarding/COLLEGE_LIST";
 import { DEPARTMENT_LIST } from "@/utils/onboarding/departments";
 
@@ -75,7 +74,7 @@ const SchoolInfoSetting = (props: Props) => {
 
         <div className={"flex flex-col gap-y-4 mt-5"}>
           {/*단과대학교*/}
-          <div className={"flex flex-col gap-y-2"}>
+          <section className={"relative flex flex-col gap-y-2"}>
             {/*label*/}
             <div className="text-gray5">
               단과대학교
@@ -109,10 +108,10 @@ const SchoolInfoSetting = (props: Props) => {
                 setIsClickFilter={setIsCollegeFilterClick}
               />
             ) : null}
-          </div>
+          </section>
 
           {/*학과*/}
-          <div className={"flex flex-col gap-y-2"}>
+          <section className={"relative flex flex-col gap-y-2"}>
             {/*label*/}
             <div className="text-gray5">
               학과
@@ -151,10 +150,10 @@ const SchoolInfoSetting = (props: Props) => {
                 setIsClickFilter={setIsDepartmentFilterClick}
               />
             ) : null}
-          </div>
+          </section>
 
           {/*학번*/}
-          <div className={"flex flex-col gap-y-2"}>
+          <section className={"flex flex-col gap-y-2"}>
             {/*label*/}
             <div className="text-gray5">
               학번
@@ -182,7 +181,7 @@ const SchoolInfoSetting = (props: Props) => {
           </section>
 
           {/*기숙사*/}
-          <div className={"flex flex-col gap-y-2"}>
+          <section className={"relative flex flex-col gap-y-2"}>
             {/*label*/}
             <div className="text-gray5">
               기숙사

--- a/dorm-front/src/components/onboarding/SchoolInfoSetting.tsx
+++ b/dorm-front/src/components/onboarding/SchoolInfoSetting.tsx
@@ -36,9 +36,9 @@ const SchoolInfoSetting = (props: Props) => {
       postData.departmentType === "학과 선택" ||
       postData.collegeType === "단과대학교" ||
       postData.nickname === "" ||
-      postData.studentCardImageUrl === "" ||
       postData.dormitoryType === "" ||
-      postData.studentNumber === 0
+      postData.studentNumber === null ||
+      String(Math.abs(postData.studentNumber)).length !== 10
     );
   };
 
@@ -48,19 +48,16 @@ const SchoolInfoSetting = (props: Props) => {
       console.log("데이터가 불완전합니다.");
       return;
     }
-    try {
-      await putProfileData(postData).then(() => {
-        onNext("PhotoStudentIDCard");
-      });
-      console.log("성공");
-    } catch (error) {
-      console.log("실패:", error);
-    }
+    onNext("PhotoStudentIDCard");
   };
 
   const onBack = () => {
     onBefore("NicknameSetting");
   };
+
+  useEffect(() => {
+    console.log(postData);
+  }, [postData]);
 
   return (
     <form onSubmit={handleSubmit}>
@@ -168,14 +165,21 @@ const SchoolInfoSetting = (props: Props) => {
             <div className={"relative flex justify-between rounded-[12px] border-[1px] border-gray1 py-3 px-4"}>
               <input
                 type={"number"}
-                maxLength={20}
+                maxLength={10}
+                defaultValue={postData.studentNumber || 0}
                 placeholder={"학번을 입력해주세요."}
                 className={"focus:outline-0 w-full"}
                 onChange={(e) => {
                   setPostData((prevState) => ({ ...prevState, studentNumber: parseInt(e.target.value) }));
                 }}></input>
             </div>
-          </div>
+            {postData.studentNumber === null ? null : String(Math.abs(postData.studentNumber)).length !== 10 ? (
+              <div
+                className={"mt-2 py-1 flex justify-center items-center bg-primaryLight rounded-[12px] text-primaryMid"}>
+                10글자를 입력해주세요.
+              </div>
+            ) : null}
+          </section>
 
           {/*기숙사*/}
           <div className={"flex flex-col gap-y-2"}>

--- a/dorm-front/src/components/onboarding/ServiceAccessRights.tsx
+++ b/dorm-front/src/components/onboarding/ServiceAccessRights.tsx
@@ -1,9 +1,16 @@
-import type { SVGProps } from "react";
+import type { Dispatch, SetStateAction, SVGProps } from "react";
 import * as React from "react";
-const ServiceAccessRights = () => {
+
+import { StepOnboarding } from "@/types/onboarding/type";
+
+interface Props {
+  onNext: Dispatch<SetStateAction<StepOnboarding>>;
+}
+const ServiceAccessRights = (props: Props) => {
+  const { onNext } = props;
   return (
     <div className={"flex flex-col min-h-screen"}>
-      <div className={"m-[30px] "}>
+      <div className={"mt-[40px] px-[30px]"}>
         <div className={"flex flex-col gap-y-[5px]"}>
           <div className={"text-h1 font-semibold"}>서비스 접근 권한 안내</div>
           <div className={"text-h5 text-gray4"}>원활한 서비스 사용을 위해 다음 권한이 필요합니다.</div>
@@ -33,7 +40,11 @@ const ServiceAccessRights = () => {
           </div>
         </div>
       </div>
-      <button className={"left-5 py-[15px] absolute bottom-5 text-white bg-primary rounded-full w-[90%] text-h5"}>
+      <button
+        onClick={() => {
+          onNext("NicknameSetting");
+        }}
+        className={"left-5 py-[15px] absolute bottom-5 text-white bg-primary rounded-full w-[90%] text-h5"}>
         동의하고 시작하기
       </button>
     </div>
@@ -70,43 +81,12 @@ function CameraIcon(props: SVGProps<SVGSVGElement>) {
 
 function AlarmIcon(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg
-      width={21}
-      height={25}
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      {...props}
-    >
-      <path
-        d="M2.77 9.713a7.633 7.633 0 0115.266 0V20.48H2.77V9.713z"
-        stroke="#000"
-        strokeWidth={1.6}
-      />
+    <svg width={21} height={25} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M2.77 9.713a7.633 7.633 0 0115.266 0V20.48H2.77V9.713z" stroke="#000" strokeWidth={1.6} />
       <rect y={19.713} width={20.491} height={1.6} rx={0.8} fill="#000" />
-      <rect
-        x={7.014}
-        y={23.048}
-        width={6.463}
-        height={1.6}
-        rx={0.8}
-        fill="#000"
-      />
-      <rect
-        x={4.641}
-        y={17.048}
-        width={3.861}
-        height={1.537}
-        rx={0.768}
-        fill="#E70050"
-      />
-      <rect
-        x={11.045}
-        width={2.56}
-        height={1.6}
-        rx={0.8}
-        transform="rotate(90 11.045 0)"
-        fill="#000"
-      />
+      <rect x={7.014} y={23.048} width={6.463} height={1.6} rx={0.8} fill="#000" />
+      <rect x={4.641} y={17.048} width={3.861} height={1.537} rx={0.768} fill="#E70050" />
+      <rect x={11.045} width={2.56} height={1.6} rx={0.8} transform="rotate(90 11.045 0)" fill="#000" />
     </svg>
   );
 }

--- a/dorm-front/src/components/onboarding/WaitForCompletion.tsx
+++ b/dorm-front/src/components/onboarding/WaitForCompletion.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
+import { Dispatch, SetStateAction } from "react";
 
 import Header from "@/components/common/Header";
-import { Dispatch, SetStateAction } from "react";
 import { StepOnboarding } from "@/types/onboarding/type";
 
 interface Props {
@@ -23,13 +23,14 @@ const WaitForCompletion = (props: Props) => {
             <div className={"absolute w-[95%] h-1 rounded-full bg-primaryMid"}></div>
           </div>
         </div>
+        <div className={"flex flex-col h-[calc(100vh-200px)]"}>
+          <div className={"mt-[32px] text-h2 font-semibold"}>학생증 등록이 완료되었습니다.</div>
 
-        <div className={"mt-[32px] text-h2 font-semibold"}>학생증 등록이 완료되었습니다.</div>
-
-        <div className={"flex-grow flex justify-center items-center"}>
-          <div className={"flex flex-col items-center justify-center bg-gray0 rounded-[20px] p-5"}>
-            <div>인증까지 최대 2일 정도 소요됩니다.</div>
-            <div>조금만 기다려 주세요!</div>
+          <div className={"flex-grow flex items-center justify-center"}>
+            <div className={"flex flex-col items-center justify-center bg-gray0 rounded-[20px] p-5 space-y-2"}>
+              <div>인증까지 최대 2일 정도 소요됩니다.</div>
+              <div>조금만 기다려 주세요!</div>
+            </div>
           </div>
         </div>
       </div>

--- a/dorm-front/src/lib/api/board.ts
+++ b/dorm-front/src/lib/api/board.ts
@@ -1,4 +1,4 @@
-import { client } from "@/lib/axios";
+import { client, sendRequest } from "@/lib/axios";
 import { ArticlePostType, PostCommentType } from "@/types/board/type";
 
 export const postArticle = async (data: ArticlePostType) => {
@@ -51,17 +51,19 @@ export const deleteArticle = async (articleId: number | string | string[]) => {
 
 export const postArticleImage = async (formData: FormData) => {
   try {
-    const response = await client.post("/images", formData, {
+    const response = await sendRequest({
       headers: {
         "Content-Type": "multipart/form-data",
-        "AccessToken": process.env.NEXT_PUBLIC_ACCESS_TOKEN,
+        AccessToken: "Bearer " + localStorage.getItem("accessToken"),
       },
+      method: "POST",
+      data: formData,
+      url: `/api/images`,
     });
-    // 성공적인 응답 처리
+    console.log(response.data);
     return response.data;
   } catch (error) {
-    // 에러 처리
-    console.error("게시글 post 에러 발생:", error);
+    console.error("사진 업로드 에러:", error);
   }
 };
 

--- a/dorm-front/src/lib/api/onboarding.ts
+++ b/dorm-front/src/lib/api/onboarding.ts
@@ -43,19 +43,15 @@ export const getJWTToken = async (accessToken: string) => {
 };
 
 export const getSearchDuplicateNickName = async (searchValue: string) => {
-  try {
-    const response = await sendRequest({
-      headers: {
-        AccessToken: "Bearer " + localStorage.getItem("accessToken"),
-      },
-      method: "GET",
-      url: `/api/members/check?nickname=${searchValue}`,
-    });
-    console.log(response.data);
-    return response.data;
-  } catch (error) {
-    console.error("닉네임 중복:", error);
-  }
+  const response = await sendRequest({
+    headers: {
+      AccessToken: "Bearer " + localStorage.getItem("accessToken"),
+    },
+    method: "GET",
+    url: `/api/members/check?nickname=${searchValue}`,
+  });
+  console.log(response.data);
+  return response.data;
 };
 
 export const putProfileInitialData = async (data: ProfileSettingType) => {

--- a/dorm-front/src/lib/api/onboarding.ts
+++ b/dorm-front/src/lib/api/onboarding.ts
@@ -58,18 +58,19 @@ export const getSearchDuplicateNickName = async (searchValue: string) => {
   }
 };
 
-export const putProfileData = async (data: ProfileSettingType) => {
+export const putProfileInitialData = async (data: ProfileSettingType) => {
   try {
-    const response = await client.put(`/api/members/initial-profiles`, data, {
+    const response = await sendRequest({
       headers: {
-        "Content-type": "application/json",
-        AccessToken: process.env.NEXT_PUBLIC_ACCESS_TOKEN,
+        AccessToken: "Bearer " + localStorage.getItem("accessToken"),
       },
+      method: "PUT",
+      data: data,
+      url: `/api/members/initial-profiles`,
     });
-    // 성공적인 응답 처리
+    console.log(response.data);
     return response.data;
   } catch (error) {
-    // 에러 처리
-    console.error("put 설정 에러", error);
+    console.error("프로필 처음 설정시 에러:", error);
   }
 };

--- a/dorm-front/src/lib/api/onboarding.ts
+++ b/dorm-front/src/lib/api/onboarding.ts
@@ -44,17 +44,17 @@ export const getJWTToken = async (accessToken: string) => {
 
 export const getSearchDuplicateNickName = async (searchValue: string) => {
   try {
-    const response = await client.get(`/members/check?nickname=${searchValue}`, {
+    const response = await sendRequest({
       headers: {
-        "Content-type": "application/json",
-        AccessToken: process.env.NEXT_PUBLIC_ACCESS_TOKEN,
+        AccessToken: "Bearer " + localStorage.getItem("accessToken"),
       },
+      method: "GET",
+      url: `/api/members/check?nickname=${searchValue}`,
     });
-    // 성공적인 응답 처리
+    console.log(response.data);
     return response.data;
   } catch (error) {
-    // 에러 처리
-    console.error("nickname 검색 에러 발생", error);
+    console.error("닉네임 중복:", error);
   }
 };
 

--- a/dorm-front/src/lib/api/onboarding.ts
+++ b/dorm-front/src/lib/api/onboarding.ts
@@ -74,3 +74,41 @@ export const putProfileInitialData = async (data: ProfileSettingType) => {
     console.error("프로필 처음 설정시 에러:", error);
   }
 };
+
+/**
+ * 회원가입 관리자 멤버 승인
+ */
+export const putMemberApproval = async (memberId: number) => {
+  try {
+    const response = await sendRequest({
+      headers: {
+        AccessToken: "Bearer " + localStorage.getItem("accessToken"),
+      },
+      method: "PUT",
+      url: `/api/verify/members/${memberId}/approvals`,
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error("프로필 처음 설정시 에러:", error);
+  }
+};
+
+/**
+ * 회원가입 관리자 멤버 거절
+ */
+export const putMemberRejection = async (memberId: number) => {
+  try {
+    const response = await sendRequest({
+      headers: {
+        AccessToken: "Bearer " + localStorage.getItem("accessToken"),
+      },
+      method: "PUT",
+      url: `/api/verify/members/${memberId}/rejections`,
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error("프로필 처음 설정시 에러:", error);
+  }
+};

--- a/dorm-front/src/lib/axios.ts
+++ b/dorm-front/src/lib/axios.ts
@@ -4,7 +4,7 @@ const client = axios.create({
   baseURL: "http://13.124.186.20:8080",
   headers: {
     "Content-type": "application/json",
-    AccessToken: localStorage.getItem("accessToken"),
+    AccessToken: "Bearer " + localStorage.getItem("accessToken"),
   },
   transformResponse: [
     (data, headers) => {

--- a/dorm-front/src/lib/axios.ts
+++ b/dorm-front/src/lib/axios.ts
@@ -63,7 +63,6 @@ const sendRequest = async (config: any) => {
     return await client(config);
   } catch (error) {
     const axiosError = error as AxiosError; // AxiosError로 캐스팅
-    console.log("axiosError", axiosError);
     if (axiosError.response && axiosError.response.status === 401) {
       // 만료된 액세스 ㅇ토큰일 경우 리프레시 토큰으로 갱신
       const { refreshToken } = getTokensFromLocalStorage();

--- a/dorm-front/src/lib/axios.ts
+++ b/dorm-front/src/lib/axios.ts
@@ -121,7 +121,7 @@ export const swrGetFetcher = async (url: any) => {
 
     const response = await sendRequest({
       headers: {
-        AccessToken: localStorage.getItem("accessToken"),
+        AccessToken: "Bearer " + localStorage.getItem("accessToken"),
       },
       method: "GET",
       url: url,

--- a/dorm-front/src/lib/hooks/useVerifyMembers.tsx
+++ b/dorm-front/src/lib/hooks/useVerifyMembers.tsx
@@ -1,9 +1,9 @@
 import useSWRInfinite from "swr/infinite";
 
 import { swrGetFetcher } from "@/lib/axios";
-import { VerifyMembersType } from "@/types/onboarding/type";
+import { VerifyMembersResponseType, VerifyMembersType } from "@/types/onboarding/type";
 
-const getKey = (pageIndex: number, previousPageData: VerifyMembersType | null) => {
+const getKey = (pageIndex: number, previousPageData: VerifyMembersResponseType | null) => {
   // 초기 요청 또는 이전 페이지 데이터가 없을 때
   if (pageIndex === 0) {
     return `/api/verify/members?page=${pageIndex}&size=10`;
@@ -12,16 +12,11 @@ const getKey = (pageIndex: number, previousPageData: VerifyMembersType | null) =
   // 이전 페이지 데이터가 없으면 종료
   if (!previousPageData) return null;
 
-  // 이전 페이지에 더 많은 데이터가 있으면 다음 페이지 요청
-  if (previousPageData?.data.totalPages === previousPageData?.data.currentPage) {
-    return `/api/verify/members?page=${pageIndex}&size=10`;
-  }
-
   // 이전 페이지에 더 이상 데이터가 없으면 null 반환
   return null;
 };
 const useVerifyMembers = () => {
-  const { data, isLoading, error, size, setSize, mutate } = useSWRInfinite<VerifyMembersType>(
+  const { data, isLoading, error, size, setSize, mutate } = useSWRInfinite<VerifyMembersResponseType>(
     (pageIndex, previousPageData) => getKey(pageIndex, previousPageData),
     swrGetFetcher,
     {
@@ -37,6 +32,7 @@ const useVerifyMembers = () => {
     isError: error,
     size: size,
     setSize: setSize,
+    mutate: mutate,
   };
 };
 export default useVerifyMembers;

--- a/dorm-front/src/lib/hooks/useVerifyMembers.tsx
+++ b/dorm-front/src/lib/hooks/useVerifyMembers.tsx
@@ -1,0 +1,42 @@
+import useSWRInfinite from "swr/infinite";
+
+import { swrGetFetcher } from "@/lib/axios";
+import { VerifyMembersType } from "@/types/onboarding/type";
+
+const getKey = (pageIndex: number, previousPageData: VerifyMembersType | null) => {
+  // 초기 요청 또는 이전 페이지 데이터가 없을 때
+  if (pageIndex === 0) {
+    return `/api/verify/members?page=${pageIndex}&size=10`;
+  }
+
+  // 이전 페이지 데이터가 없으면 종료
+  if (!previousPageData) return null;
+
+  // 이전 페이지에 더 많은 데이터가 있으면 다음 페이지 요청
+  if (previousPageData?.data.totalPages === previousPageData?.data.currentPage) {
+    return `/api/verify/members?page=${pageIndex}&size=10`;
+  }
+
+  // 이전 페이지에 더 이상 데이터가 없으면 null 반환
+  return null;
+};
+const useVerifyMembers = () => {
+  const { data, isLoading, error, size, setSize, mutate } = useSWRInfinite<VerifyMembersType>(
+    (pageIndex, previousPageData) => getKey(pageIndex, previousPageData),
+    swrGetFetcher,
+    {
+      revalidateAll: true,
+    },
+  );
+
+  const parseResultList = data ? data.map((noNonVerifiedStudentCard) => noNonVerifiedStudentCard).flat() : null;
+
+  return {
+    nonVerifiedStudentCardList: parseResultList ? parseResultList : null,
+    isLoading: !error && !data,
+    isError: error,
+    size: size,
+    setSize: setSize,
+  };
+};
+export default useVerifyMembers;

--- a/dorm-front/src/recoil/onboarding/atom.ts
+++ b/dorm-front/src/recoil/onboarding/atom.ts
@@ -5,11 +5,11 @@ import { ProfileSettingType } from "@/types/global";
 export const profileSettingAtom = atom<ProfileSettingType>({
   key: "profileSettingAtom",
   default: {
-    nickname: "유림",
-    studentCardImageUrl: "https://k.kakaocdn.net/dn/G4MPH/btrfw4guzVh/iXmuhGiV1QRMsZkMsKRrc1/img_640x640.jpg",
+    nickname: "",
+    studentCardImageUrl: "",
     collegeType: "단과대학교",
     departmentType: "학과선택",
     studentNumber: 0,
-    dormitoryType: "본관",
+    dormitoryType: "",
   },
 });

--- a/dorm-front/src/recoil/onboarding/atom.ts
+++ b/dorm-front/src/recoil/onboarding/atom.ts
@@ -9,7 +9,7 @@ export const profileSettingAtom = atom<ProfileSettingType>({
     studentCardImageUrl: "",
     collegeType: "단과대학교",
     departmentType: "학과선택",
-    studentNumber: 0,
+    studentNumber: null,
     dormitoryType: "",
   },
 });

--- a/dorm-front/src/types/global.d.ts
+++ b/dorm-front/src/types/global.d.ts
@@ -60,6 +60,6 @@ export interface ProfileSettingType {
   studentCardImageUrl: string;
   collegeType: CollegeType;
   departmentType: string;
-  studentNumber: number;
+  studentNumber: number | null;
   dormitoryType: string;
 }

--- a/dorm-front/src/types/onboarding/type.ts
+++ b/dorm-front/src/types/onboarding/type.ts
@@ -1,4 +1,5 @@
-import { string } from "prop-types";
+import { number, string } from "prop-types";
+import { AxiosHeaders } from "axios";
 
 export type CollegeType =
   | "단과대학교"
@@ -45,3 +46,15 @@ export type StepOnboarding =
   | "SchoolInfoSetting"
   | "PhotoStudentIDCard"
   | "WaitForCompletion";
+
+export interface SearchDuplicateNickNameResponseType {
+  data: SearchDuplicateNickNameType;
+  headers: AxiosHeaders;
+}
+
+export interface SearchDuplicateNickNameType {
+  code: number;
+  data: {
+    isDuplicated: boolean;
+  };
+}

--- a/dorm-front/src/types/onboarding/type.ts
+++ b/dorm-front/src/types/onboarding/type.ts
@@ -39,4 +39,9 @@ export interface DepartmentType {
   바이오헬스학부: string[];
 }
 
-export type StepOnboarding = "NicknameSetting" | "SchoolInfoSetting" | "PhotoStudentIDCard" | "WaitForCompletion";
+export type StepOnboarding =
+  | "ServiceAccessRights"
+  | "NicknameSetting"
+  | "SchoolInfoSetting"
+  | "PhotoStudentIDCard"
+  | "WaitForCompletion";

--- a/dorm-front/src/types/onboarding/type.ts
+++ b/dorm-front/src/types/onboarding/type.ts
@@ -1,5 +1,5 @@
-import { number, string } from "prop-types";
 import { AxiosHeaders } from "axios";
+import { number, string } from "prop-types";
 
 export type CollegeType =
   | "단과대학교"
@@ -57,4 +57,30 @@ export interface SearchDuplicateNickNameType {
   data: {
     isDuplicated: boolean;
   };
+}
+
+/**
+ * 관리자페이지 승인 멤버 데이터
+ */
+export interface VerifyMembersResponseType {
+  data: VerifyMembersType;
+  headers: AxiosHeaders;
+}
+
+export interface VerifyMembersType {
+  code: number;
+  data: {
+    totalElements: number;
+    totalPages: number;
+    currentPage: number;
+    nonVerifiedStudentCards: NonVerifiedStudentCardsType[];
+  };
+}
+
+export interface NonVerifiedStudentCardsType {
+  memberId: number;
+  name: string;
+  studentNumber: string;
+  Department: string;
+  studentCardUrl: string;
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

온보딩 페이지 기능을 구현하였습니다.
1. 이용약관처리 부분을 추가하였습니다.
2. 이름 중복 체크하는 부분을 구현하였습니다. 만약 이름이 중복될 경우에는 409 에러를 감지하였습니다. 
3. 학생증을 업로드하는 페이지를 구현하였습니다.
4. 학생증 인증 페이지인 admin페이지를 구현하였습니다. 

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

```
export const getSearchDuplicateNickName = async (searchValue: string) => {
  const response = await sendRequest({
    headers: {
      AccessToken: "Bearer " + localStorage.getItem("accessToken"),
    },
    method: "GET",
    url: `/api/members/check?nickname=${searchValue}`,
  });
  console.log(response.data);
  return response.data;
};
```
api 정의하는 부분에 try, catch를 넣어 page.tsx선언부분에서 error를 잘 감지 못하는 일이 발생하였습니다. 따라서 해당 부분에 try, catch부분을 제거하여 409를 catch할 수 있도록 코드 일부분을 수정하였습니다. 