### PR TITLE
[#35] 채팅 에러 수정

### DIFF
--- a/dorm-front/src/app/(main)/board/[id]/page.tsx
+++ b/dorm-front/src/app/(main)/board/[id]/page.tsx
@@ -243,6 +243,7 @@ const BoardDetail = () => {
             <CommunicationBox
               setIsArticleFavoritesList={setIsArticleFavoritesListClicked}
               isWriter={articleDetail?.data.isWriter}
+              memberId={articleDetail?.data.memberId}
               articleId={articleDetail?.data.articleId}
               articleMutate={articleMutate}
               wishCount={articleDetail?.data.wishCount}

--- a/dorm-front/src/app/(main)/chat/page.tsx
+++ b/dorm-front/src/app/(main)/chat/page.tsx
@@ -158,6 +158,7 @@ const Chat = () => {
               });
             })}
         </section>
+        <div className={"h-[90px]"} />
         <NavBar />
       </div>
     </>

--- a/dorm-front/src/components/chat/LeaveChatRoomAlertModal.tsx
+++ b/dorm-front/src/components/chat/LeaveChatRoomAlertModal.tsx
@@ -38,7 +38,7 @@ const LeaveChatRoomAlertModal = (props: Props) => {
         </div>
 
         {/* 버튼 */}
-        <div className={"mt-6 flex gap-x-3"}>
+        <div className={"w-full mt-6 flex gap-x-3"}>
           <button className={"w-full bg-gray1 rounded-[20px] text-h5 text-gray5 py-[14px] px-[35px]"}>취소</button>
           <button
             onClick={() => {

--- a/dorm-front/src/components/chat/OtherUserChatContent.tsx
+++ b/dorm-front/src/components/chat/OtherUserChatContent.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { useEffect } from "react";
+import { SVGProps, useEffect } from "react";
 
 import useUserProfile from "@/lib/hooks/useUserProfile";
 interface Props {
@@ -27,19 +27,23 @@ const OtherUserChatContent = (props: Props) => {
   };
 
   useEffect(() => {
-    console.log("내 채팅", message)
+    console.log("내 채팅", message);
   }, [message]);
 
   return (
     <div className={"flex items-end px-5 w-full gap-x-2"}>
       <div className={"flex justify-start gap-x-1"}>
-        <div className={"relative w-[36px] h-[36px]"}>
-          <Image
-            src={userProfileData?.data.profileUrl}
-            alt={userProfileData?.data.profileUrl}
-            fill
-            className={"object-cover rounded-full"}></Image>
-        </div>
+        {userProfileData ? (
+          <div className={"relative w-[36px] h-[36px]"}>
+            <Image
+              src={userProfileData.data.profileUrl}
+              alt={userProfileData.data.profileUrl}
+              fill
+              className={"object-cover rounded-full"}></Image>
+          </div>
+        ) : (
+          <ProfileIcon />
+        )}
         <div className={"flex flex-col gap-y-1"}>
           <div className={"text-h5"}>{userProfileData?.data.nickname}</div>
           <div>
@@ -53,3 +57,9 @@ const OtherUserChatContent = (props: Props) => {
   );
 };
 export default OtherUserChatContent;
+
+const ProfileIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={37} height={36} fill="none" {...props}>
+    <path fill="#E4E5E7" d="M18.507 36c9.941 0 18-8.059 18-18s-8.059-18-18-18-18 8.059-18 18 8.059 18 18 18" />
+  </svg>
+);

--- a/dorm-front/src/components/common/ProfileModal.tsx
+++ b/dorm-front/src/components/common/ProfileModal.tsx
@@ -9,14 +9,8 @@ import { createChatRoom, getRoomId, patchRejoinChatRoom } from "@/lib/api/chat";
 import { postFollow } from "@/lib/api/common";
 import useUserProfile from "@/lib/hooks/useUserProfile";
 import { chatRoomUUIDAtom, memberIdAtom } from "@/recoil/chat/atom";
+import { ErrorResponseData } from "@/types/chat/page";
 
-interface ErrorResponseData {
-  code?: number;
-  data?: {
-    errorMessage: string;
-    [key: string]: any; // 추가 필드 허용
-  };
-}
 interface Props {
   memberId: number | undefined;
 }

--- a/dorm-front/src/components/room-mate/ApplicationReceivedProfile.tsx
+++ b/dorm-front/src/components/room-mate/ApplicationReceivedProfile.tsx
@@ -1,8 +1,14 @@
+import { AxiosError } from "axios";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import * as React from "react";
 import { SVGProps, useState } from "react";
+import { useRecoilState } from "recoil";
 
+import { createChatRoom, getRoomId, patchRejoinChatRoom } from "@/lib/api/chat";
 import { deleteRoomMateMatchingRequest, postAcceptMatchingRequest } from "@/lib/api/room-mate";
+import { chatRoomUUIDAtom, memberIdAtom } from "@/recoil/chat/atom";
+import { ErrorResponseData } from "@/types/chat/page";
 
 interface Props {
   memberId: number;
@@ -15,6 +21,41 @@ interface Props {
 const ApplicationReceivedProfile = (props: Props) => {
   const { memberId, profileUrl, nickname, isMatchable, mutate } = props;
   const [isPreferredLifestyleReviewerOpen, setIsPreferredLifestyleReviewerOpen] = useState(false);
+
+  const [chatRoomUUID, setChatRoomUUID] = useRecoilState(chatRoomUUIDAtom);
+  const [memberIdState, setMemberIdState] = useRecoilState(memberIdAtom);
+  const router = useRouter();
+
+  const handleSubmit = async (memberId: string | string[] | number | undefined) => {
+    try {
+      const response = await createChatRoom(memberId);
+      console.log("response", response);
+      if (response && response.data && response.data.code === 201) {
+        setChatRoomUUID(response.data.data.roomUUID);
+        setMemberIdState(memberId);
+        router.push(`/chat/${response.data.data.chatRoomId}`);
+      }
+    } catch (error: any) {
+      const axiosError = error as AxiosError<ErrorResponseData>; // AxiosError로 캐스팅
+      console.log("axiosError", axiosError.response?.status);
+      if (axiosError.response?.status === 409) {
+        if (axiosError.response?.data?.data?.errorMessage === "채팅방이 존재합니다. 재입장해주세요.") {
+          patchRejoinChatRoom(memberId).then((res) => {
+            setChatRoomUUID(res.data.data.roomUUID);
+            setMemberIdState(memberId);
+            console.log("res", res);
+          });
+        } else if (axiosError.response?.data?.data?.errorMessage === "이미 채팅방에 입장한 상태입니다") {
+          getRoomId(memberId).then((response) => {
+            console.log("response", response);
+            setChatRoomUUID(response.data.data.roomUUID);
+            setMemberIdState(memberId);
+            router.push(`/chat/${response.data.data.chatRoomId}`);
+          });
+        }
+      }
+    }
+  };
 
   return (
     <div className={"flex flex-col gap-y-1 py-3 px-4 rounded-[24px] border border-gray1 "}>
@@ -79,7 +120,11 @@ const ApplicationReceivedProfile = (props: Props) => {
           }>
           수락
         </button>
-        <button className={"border border-gray1 rounded-full p-2"}>
+        <button
+          onClick={() => {
+            handleSubmit(memberId);
+          }}
+          className={"border border-gray1 rounded-full p-2"}>
           <FollowChatIcon />
         </button>
       </section>

--- a/dorm-front/src/components/room-mate/MyRoomMateProfile.tsx
+++ b/dorm-front/src/components/room-mate/MyRoomMateProfile.tsx
@@ -1,10 +1,16 @@
+import { AxiosError } from "axios";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { SVGProps } from "react";
 import * as React from "react";
 
+import { createChatRoom, getRoomId, patchRejoinChatRoom } from "@/lib/api/chat";
 import { deleteRoomMateWish, postRoomMateWish } from "@/lib/api/room-mate";
 import useRoomMateRecommendResultProfile from "@/lib/hooks/useRoomMateRecommendResultProfile";
 import useRoomMateWishStatus from "@/lib/hooks/useRoomMateWishStatus";
+import { useRecoilState } from "recoil";
+import { chatRoomUUIDAtom, memberIdAtom } from "@/recoil/chat/atom";
+import { ErrorResponseData } from "@/types/chat/page";
 
 interface Props {
   memberId: number | undefined;
@@ -14,6 +20,9 @@ const MyRoomMateProfile = (props: Props) => {
   const { memberId, setIsConfirmRoommateMatchCancelOpen } = props;
   const { recommendRoomMateProfile } = useRoomMateRecommendResultProfile(memberId);
   const { wishStatus, wishStatusMutate } = useRoomMateWishStatus(memberId);
+  const [chatRoomUUID, setChatRoomUUID] = useRecoilState(chatRoomUUIDAtom);
+  const [memberIdState, setMemberIdState] = useRecoilState(memberIdAtom);
+  const router = useRouter();
 
   function calculateKoreanAge(birthDate: string | undefined) {
     if (!birthDate) return "";
@@ -27,6 +36,37 @@ const MyRoomMateProfile = (props: Props) => {
     // 한국 나이 계산 (현재 연도 - 출생 연도 + 1)
     return currentYear - parseInt(birthYear) + 1;
   }
+
+  const handleSubmit = async (memberId: string | string[] | number | undefined) => {
+    try {
+      const response = await createChatRoom(memberId);
+      console.log("response", response);
+      if (response && response.data && response.data.code === 201) {
+        setChatRoomUUID(response.data.data.roomUUID);
+        setMemberIdState(memberId);
+        router.push(`/chat/${response.data.data.chatRoomId}`);
+      }
+    } catch (error: any) {
+      const axiosError = error as AxiosError<ErrorResponseData>; // AxiosError로 캐스팅
+      console.log("axiosError", axiosError.response?.status);
+      if (axiosError.response?.status === 409) {
+        if (axiosError.response?.data?.data?.errorMessage === "채팅방이 존재합니다. 재입장해주세요.") {
+          patchRejoinChatRoom(memberId).then((res) => {
+            setChatRoomUUID(res.data.data.roomUUID);
+            setMemberIdState(memberId);
+            console.log("res", res);
+          });
+        } else if (axiosError.response?.data?.data?.errorMessage === "이미 채팅방에 입장한 상태입니다") {
+          getRoomId(memberId).then((response) => {
+            console.log("response", response);
+            setChatRoomUUID(response.data.data.roomUUID);
+            setMemberIdState(memberId);
+            router.push(`/chat/${response.data.data.chatRoomId}`);
+          });
+        }
+      }
+    }
+  };
 
   return (
     <div className={"flex flex-col gap-y-3 rounded-[32px] border-[1px] border-gray1 p-5"}>
@@ -104,7 +144,9 @@ const MyRoomMateProfile = (props: Props) => {
             {wishStatus?.data.isRoommateWished ? <WhiteHeartIcon /> : <HeartIcon />}
           </button>
           <button
-            //TODO: 채팅이동
+            onClick={() => {
+              handleSubmit(memberId);
+            }}
             className={
               "flex py-[5px] px-5 rounded-full border-[1px] border-gray1 items-center gap-x-1 text-gray5 text-h5"
             }>

--- a/dorm-front/src/components/room-mate/RoomMateDoomzBasicProfile.tsx
+++ b/dorm-front/src/components/room-mate/RoomMateDoomzBasicProfile.tsx
@@ -1,13 +1,19 @@
 "use client";
 
+import { AxiosError } from "axios";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import * as React from "react";
 import { SVGProps } from "react";
+import { useRecoilState } from "recoil";
 
 import PreferredLifestyleReviewer from "@/components/room-mate/PreferredLifestyleReviewer";
+import { createChatRoom, getRoomId, patchRejoinChatRoom } from "@/lib/api/chat";
 import { deleteRoomMateWish, postRoomMateMatchingRequest, postRoomMateWish } from "@/lib/api/room-mate";
 import useRoomMateRecommendResultProfile from "@/lib/hooks/useRoomMateRecommendResultProfile";
 import useRoomMateWishStatus from "@/lib/hooks/useRoomMateWishStatus";
+import { chatRoomUUIDAtom, memberIdAtom } from "@/recoil/chat/atom";
+import { ErrorResponseData } from "@/types/chat/page";
 
 interface Props {
   memberId: string | string[] | number;
@@ -16,6 +22,40 @@ const RoomMateDoomzBasicProfile = (props: Props) => {
   const { memberId } = props;
   const { wishStatus, wishStatusMutate } = useRoomMateWishStatus(memberId);
   const { recommendRoomMateProfile } = useRoomMateRecommendResultProfile(memberId);
+  const [chatRoomUUID, setChatRoomUUID] = useRecoilState(chatRoomUUIDAtom);
+  const [memberIdState, setMemberIdState] = useRecoilState(memberIdAtom);
+  const router = useRouter();
+
+  const handleSubmit = async (memberId: string | string[] | number | undefined) => {
+    try {
+      const response = await createChatRoom(memberId);
+      console.log("response", response);
+      if (response && response.data && response.data.code === 201) {
+        setChatRoomUUID(response.data.data.roomUUID);
+        setMemberIdState(memberId);
+        router.push(`/chat/${response.data.data.chatRoomId}`);
+      }
+    } catch (error: any) {
+      const axiosError = error as AxiosError<ErrorResponseData>; // AxiosError로 캐스팅
+      console.log("axiosError", axiosError.response?.status);
+      if (axiosError.response?.status === 409) {
+        if (axiosError.response?.data?.data?.errorMessage === "채팅방이 존재합니다. 재입장해주세요.") {
+          patchRejoinChatRoom(memberId).then((res) => {
+            setChatRoomUUID(res.data.data.roomUUID);
+            setMemberIdState(memberId);
+            console.log("res", res);
+          });
+        } else if (axiosError.response?.data?.data?.errorMessage === "이미 채팅방에 입장한 상태입니다") {
+          getRoomId(memberId).then((response) => {
+            console.log("response", response);
+            setChatRoomUUID(response.data.data.roomUUID);
+            setMemberIdState(memberId);
+            router.push(`/chat/${response.data.data.chatRoomId}`);
+          });
+        }
+      }
+    }
+  };
 
   return (
     <section className={"mx-5 flex flex-col gap-y-5"}>
@@ -71,7 +111,9 @@ const RoomMateDoomzBasicProfile = (props: Props) => {
             {wishStatus?.data.isRoommateWished ? <WhiteHeartIcon /> : <HeartIcon />}
           </button>
           <button
-            //TODO: 채팅이동
+            onClick={() => {
+              handleSubmit(memberId);
+            }}
             className={
               "flex py-[5px] px-5 rounded-full border-[1px] border-gray1 items-center gap-x-1 text-gray5 text-h5"
             }>

--- a/dorm-front/src/components/room-mate/RoommateMatchListProfile.tsx
+++ b/dorm-front/src/components/room-mate/RoommateMatchListProfile.tsx
@@ -1,13 +1,19 @@
+import { AxiosError } from "axios";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import * as React from "react";
 import { SVGProps, useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
 
 import PreferredLifestyleReviewer from "@/components/room-mate/PreferredLifestyleReviewer";
+import { createChatRoom, getRoomId, patchRejoinChatRoom } from "@/lib/api/chat";
 import { deleteFollowing, postFollow } from "@/lib/api/common";
 import { deleteRoomMateWish, postRoomMateWish } from "@/lib/api/room-mate";
 import useFollowStatus from "@/lib/hooks/useFollowStatus";
 import useRoomMateRecommendResultProfile from "@/lib/hooks/useRoomMateRecommendResultProfile";
 import useRoomMateWishStatus from "@/lib/hooks/useRoomMateWishStatus";
+import { chatRoomUUIDAtom, memberIdAtom } from "@/recoil/chat/atom";
+import { ErrorResponseData } from "@/types/chat/page";
 
 interface Props {
   memberId: number;
@@ -20,6 +26,40 @@ const RoommateMatchListProfile = (props: Props) => {
   const { wishStatus, wishStatusMutate } = useRoomMateWishStatus(memberId);
   const [isPreferredLifestyleReviewerOpen, setIsPreferredLifestyleReviewerOpen] = useState(false);
   const { followStatus } = useFollowStatus(memberId);
+  const [chatRoomUUID, setChatRoomUUID] = useRecoilState(chatRoomUUIDAtom);
+  const [memberIdState, setMemberIdState] = useRecoilState(memberIdAtom);
+  const router = useRouter();
+
+  const handleSubmit = async (memberId: string | string[] | number | undefined) => {
+    try {
+      const response = await createChatRoom(memberId);
+      console.log("response", response);
+      if (response && response.data && response.data.code === 201) {
+        setChatRoomUUID(response.data.data.roomUUID);
+        setMemberIdState(memberId);
+        router.push(`/chat/${response.data.data.chatRoomId}`);
+      }
+    } catch (error: any) {
+      const axiosError = error as AxiosError<ErrorResponseData>; // AxiosError로 캐스팅
+      console.log("axiosError", axiosError.response?.status);
+      if (axiosError.response?.status === 409) {
+        if (axiosError.response?.data?.data?.errorMessage === "채팅방이 존재합니다. 재입장해주세요.") {
+          patchRejoinChatRoom(memberId).then((res) => {
+            setChatRoomUUID(res.data.data.roomUUID);
+            setMemberIdState(memberId);
+            console.log("res", res);
+          });
+        } else if (axiosError.response?.data?.data?.errorMessage === "이미 채팅방에 입장한 상태입니다") {
+          getRoomId(memberId).then((response) => {
+            console.log("response", response);
+            setChatRoomUUID(response.data.data.roomUUID);
+            setMemberIdState(memberId);
+            router.push(`/chat/${response.data.data.chatRoomId}`);
+          });
+        }
+      }
+    }
+  };
 
   useEffect(() => {
     console.log("recommendRoomMateProfile", recommendRoomMateProfile);
@@ -105,7 +145,9 @@ const RoommateMatchListProfile = (props: Props) => {
           </button>
         </div>
         <button
-          //TODO: 채팅이동
+          onClick={() => {
+            handleSubmit(memberId);
+          }}
           className={"p-[10px] rounded-full border-[1px] border-gray1 items-center gap-x-1"}>
           <FollowChatIcon />
         </button>

--- a/dorm-front/src/lib/api/chat.ts
+++ b/dorm-front/src/lib/api/chat.ts
@@ -27,12 +27,32 @@ export const patchLeaveChatRoom = async (roomId: string | string[]) => {
         AccessToken: "Bearer " + localStorage.getItem("accessToken"),
       },
       method: "PATCH",
-      url: `/chats/rooms/${roomId}`,
+      url: `/api/chats/rooms/${roomId}`,
     });
     console.log(response.data);
     return response.data;
   } catch (error) {
     console.error("채팅방 나가기 에러:", error);
+  }
+};
+
+/**
+ * 채팅방 재입장
+ */
+export const patchRejoinChatRoom = async (memberId: number | undefined) => {
+  try {
+    const response = await sendRequest({
+      headers: {
+        "Content-type": "application/json",
+        AccessToken: "Bearer " + localStorage.getItem("accessToken"),
+      },
+      method: "PATCH",
+      url: `/api/chats/members/${memberId}`,
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error("채팅방 재입장 에러:", error);
   }
 };
 

--- a/dorm-front/src/lib/api/chat.ts
+++ b/dorm-front/src/lib/api/chat.ts
@@ -3,7 +3,7 @@ import { client, sendRequest } from "@/lib/axios";
 /**
  * 룸메 매칭 신청
  */
-export const createChatRoom = async (roomId: number | undefined) => {
+export const createChatRoom = async (roomId: string | string[] | number | undefined) => {
   const response = await sendRequest({
     headers: {
       "Content-type": "application/json",
@@ -39,7 +39,7 @@ export const patchLeaveChatRoom = async (roomId: string | string[]) => {
 /**
  * 채팅방 재입장
  */
-export const patchRejoinChatRoom = async (memberId: number | undefined) => {
+export const patchRejoinChatRoom = async (memberId: string | string[] | number | undefined) => {
   try {
     const response = await sendRequest({
       headers: {

--- a/dorm-front/src/recoil/chat/atom.ts
+++ b/dorm-front/src/recoil/chat/atom.ts
@@ -10,7 +10,7 @@ export const chatRoomUUIDAtom = atom<string>({
   default: "",
 });
 
-export const memberIdAtom = atom<number | undefined>({
+export const memberIdAtom = atom<string | string[] | number | undefined>({
   key: "memberIdAtom",
   default: 0,
 });

--- a/dorm-front/src/types/chat/page.tsx
+++ b/dorm-front/src/types/chat/page.tsx
@@ -58,3 +58,12 @@ export interface ResponseUnreadChattingTotalCountType {
     totalCount: number;
   };
 }
+
+export interface ErrorResponseData {
+  code?: number;
+  data?: {
+    errorMessage: string;
+    [key: string]: any; // 추가 필드 허용
+  };
+}
+

--- a/dorm-front/src/types/chat/page.tsx
+++ b/dorm-front/src/types/chat/page.tsx
@@ -16,6 +16,7 @@ export interface ChatRoomsDataType {
 export interface ChatRoomType {
   roomId: number;
   memberId: number;
+  roomUUID: string;
   memberNickname: string;
   memberProfileUrl: string;
   unReadCount: number;
@@ -43,6 +44,8 @@ export interface ChatRoomMessageType {
 export interface chatHistoryType {
   chatMessage: string;
   isSender: false;
+  roomId: number;
+  roomUUID: string;
   memberId: number;
   memberNickname: string;
   memberProfileUrl: string;

--- a/dorm-front/src/types/room-mate/type.ts
+++ b/dorm-front/src/types/room-mate/type.ts
@@ -256,6 +256,7 @@ export interface AllDoomzListType {
 
 export interface MemberProfileType {
   memberId: number;
+  roomUUID: string;
   nickname: string;
   profileUrl: string;
   isFollowing: boolean;


### PR DESCRIPTION
Closes #35 
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

- 채팅방에서 메시지가 보내지지 않는 문제가 발생하였습니다.
  - uuid와 memberId를 전역으로 관리하여, 채팅방에 입장할 경우에 uuid와 memberId가 있도록 구현하였습니다.

- 채팅방에서 나간 다음 다시 입장할 경우에 409에러가 발생하여 메시지가 보내지지 않는 에러가 발생하였습니다.
  - 내가 채팅방을 나가더라도 상대방이 있을 경우에는 채팅방이 여전히 존재하기 때문에 재입장 api를 요청하여 재입장 시켰습니다.

- 여러 컴포넌트에서 채팅방으로 이동할 경우에 채팅방을 처음 만들고, 기존에 채팅방이 있는 경우에는 409에러를 감지하여 재입장할 수 있도록 코드를 구현하였습니다. 

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
